### PR TITLE
Illustrating the main behavior of `MiddlewareHandler` at the first example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ const ChainedFunction = new MiddlewareHandler()
       ctx.done(null, { status: 200 });
    })
    .listen();
+   
+module.exports = ChainedFunction;
 ```
 
 ## Install


### PR DESCRIPTION
Including a line of code at first example to illustrate the main behavior of `MiddlewareHandler`.

Developers are not able to clearly understand that `MiddlewareHandler.listen()` exports a default Azure Function module.